### PR TITLE
Add NewsAPI and Alpha Vantage API clients (ZT-13)

### DIFF
--- a/src/services/README.md
+++ b/src/services/README.md
@@ -1,0 +1,88 @@
+# API Services
+
+This directory contains all API client implementations for Early Riser.
+
+## Available Clients
+
+### NewsAPI Client (`newsAPI.ts`)
+
+Fetches news articles from NewsAPI.org.
+
+**Usage:**
+
+```typescript
+import { newsAPI } from '@/services';
+
+// Get top headlines
+const headlines = await newsAPI.getTopHeadlines({
+  country: 'us',
+  category: 'business',
+  pageSize: 10,
+});
+
+// Search for specific news
+const articles = await newsAPI.searchNews({
+  q: 'stock market',
+  language: 'en',
+  sortBy: 'publishedAt',
+});
+```
+
+### Alpha Vantage Client (`alphaVantage.ts`)
+
+Provides stock market data from Alpha Vantage.
+
+**Usage:**
+
+```typescript
+import { alphaVantage } from '@/services';
+
+// Get real-time quote
+const quote = await alphaVantage.getQuote('AAPL');
+
+// Get daily time series
+const timeSeries = await alphaVantage.getDailyTimeSeries('MSFT');
+
+// Get intraday data
+const intraday = await alphaVantage.getIntradayTimeSeries('GOOGL', '5min');
+
+// Search for symbols
+const results = await alphaVantage.searchSymbol('tesla');
+```
+
+## Configuration
+
+All API clients read their configuration from environment variables. See `.env.example` for required variables.
+
+Required environment variables:
+- `VITE_NEWS_API_KEY` - NewsAPI.org API key
+- `VITE_MARKET_DATA_API_KEY` - Alpha Vantage API key
+- `VITE_CRYPTO_API_KEY` - Cryptocurrency API key (for future use)
+- `VITE_WS_URL` - WebSocket URL (for future real-time data)
+
+## Error Handling
+
+All API clients include:
+- Automatic error logging
+- Descriptive error messages
+- Type-safe responses
+- Configuration validation
+
+## Testing
+
+To test if your API keys are configured:
+
+```typescript
+import { newsAPI, alphaVantage } from '@/services';
+
+console.log('NewsAPI configured:', newsAPI.isConfigured());
+console.log('Alpha Vantage configured:', alphaVantage.isConfigured());
+```
+
+## Rate Limits
+
+Be aware of API rate limits:
+- NewsAPI: 100 requests per day (free tier)
+- Alpha Vantage: 5 API requests per minute and 500 requests per day (free tier)
+
+Consider implementing caching to avoid hitting rate limits.

--- a/src/services/alphaVantage.ts
+++ b/src/services/alphaVantage.ts
@@ -1,0 +1,159 @@
+import type {
+  AlphaVantageGlobalQuote,
+  AlphaVantageTimeSeriesDaily,
+  MarketQuote,
+} from '../types/api';
+
+class AlphaVantageClient {
+  private apiKey: string;
+  private baseUrl = 'https://www.alphavantage.co/query';
+
+  constructor(apiKey?: string) {
+    this.apiKey = apiKey || import.meta.env.VITE_MARKET_DATA_API_KEY || '';
+    
+    if (!this.apiKey) {
+      console.warn('Alpha Vantage API key not configured');
+    }
+  }
+
+  /**
+   * Get real-time quote for a symbol
+   */
+  async getQuote(symbol: string): Promise<MarketQuote> {
+    const params = new URLSearchParams({
+      function: 'GLOBAL_QUOTE',
+      symbol: symbol.toUpperCase(),
+      apikey: this.apiKey,
+    });
+
+    try {
+      const response = await fetch(`${this.baseUrl}?${params}`);
+      
+      if (!response.ok) {
+        throw new Error(`Alpha Vantage error: ${response.status} ${response.statusText}`);
+      }
+
+      const data: AlphaVantageGlobalQuote = await response.json();
+      
+      if (!data['Global Quote'] || Object.keys(data['Global Quote']).length === 0) {
+        throw new Error(`No data returned for symbol: ${symbol}`);
+      }
+
+      return this.normalizeQuote(data['Global Quote']);
+    } catch (error) {
+      console.error(`Failed to fetch quote for ${symbol}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get daily time series data for a symbol
+   */
+  async getDailyTimeSeries(
+    symbol: string,
+    outputSize: 'compact' | 'full' = 'compact'
+  ): Promise<AlphaVantageTimeSeriesDaily> {
+    const params = new URLSearchParams({
+      function: 'TIME_SERIES_DAILY',
+      symbol: symbol.toUpperCase(),
+      outputsize: outputSize,
+      apikey: this.apiKey,
+    });
+
+    try {
+      const response = await fetch(`${this.baseUrl}?${params}`);
+      
+      if (!response.ok) {
+        throw new Error(`Alpha Vantage error: ${response.status} ${response.statusText}`);
+      }
+
+      const data: AlphaVantageTimeSeriesDaily = await response.json();
+      
+      if (!data['Time Series (Daily)']) {
+        throw new Error(`No time series data returned for symbol: ${symbol}`);
+      }
+
+      return data;
+    } catch (error) {
+      console.error(`Failed to fetch time series for ${symbol}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Get intraday time series data
+   */
+  async getIntradayTimeSeries(
+    symbol: string,
+    interval: '1min' | '5min' | '15min' | '30min' | '60min' = '5min'
+  ) {
+    const params = new URLSearchParams({
+      function: 'TIME_SERIES_INTRADAY',
+      symbol: symbol.toUpperCase(),
+      interval,
+      apikey: this.apiKey,
+    });
+
+    try {
+      const response = await fetch(`${this.baseUrl}?${params}`);
+      
+      if (!response.ok) {
+        throw new Error(`Alpha Vantage error: ${response.status} ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error(`Failed to fetch intraday data for ${symbol}:`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Search for symbols
+   */
+  async searchSymbol(keywords: string) {
+    const params = new URLSearchParams({
+      function: 'SYMBOL_SEARCH',
+      keywords,
+      apikey: this.apiKey,
+    });
+
+    try {
+      const response = await fetch(`${this.baseUrl}?${params}`);
+      
+      if (!response.ok) {
+        throw new Error(`Alpha Vantage error: ${response.status} ${response.statusText}`);
+      }
+
+      return await response.json();
+    } catch (error) {
+      console.error(`Failed to search symbols for "${keywords}":`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * Normalize Alpha Vantage quote to internal format
+   */
+  private normalizeQuote(quote: AlphaVantageGlobalQuote['Global Quote']): MarketQuote {
+    return {
+      symbol: quote['01. symbol'],
+      price: parseFloat(quote['05. price']),
+      change: parseFloat(quote['09. change']),
+      changePercent: parseFloat(quote['10. change percent'].replace('%', '')),
+      volume: parseInt(quote['06. volume']),
+      timestamp: quote['07. latest trading day'],
+    };
+  }
+
+  /**
+   * Check if API key is configured
+   */
+  isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+}
+
+// Export singleton instance
+export const alphaVantage = new AlphaVantageClient();
+export default alphaVantage;

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -1,0 +1,67 @@
+/**
+ * API Configuration
+ * Central configuration for all API clients
+ */
+
+export const API_CONFIG = {
+  newsAPI: {
+    key: import.meta.env.VITE_NEWS_API_KEY || '',
+    baseUrl: 'https://newsapi.org/v2',
+  },
+  alphaVantage: {
+    key: import.meta.env.VITE_MARKET_DATA_API_KEY || '',
+    baseUrl: 'https://www.alphavantage.co/query',
+  },
+  crypto: {
+    key: import.meta.env.VITE_CRYPTO_API_KEY || '',
+  },
+  websocket: {
+    url: import.meta.env.VITE_WS_URL || '',
+  },
+  app: {
+    environment: import.meta.env.VITE_ENVIRONMENT || 'development',
+    logLevel: import.meta.env.VITE_LOG_LEVEL || 'info',
+  },
+  features: {
+    notifications: import.meta.env.VITE_ENABLE_NOTIFICATIONS === 'true',
+    darkMode: import.meta.env.VITE_ENABLE_DARK_MODE === 'true',
+    aiInsights: import.meta.env.VITE_ENABLE_AI_INSIGHTS === 'true',
+  },
+  intervals: {
+    newsRefresh: parseInt(import.meta.env.VITE_NEWS_REFRESH_INTERVAL || '60000'),
+    priceRefresh: parseInt(import.meta.env.VITE_PRICE_REFRESH_INTERVAL || '30000'),
+  },
+};
+
+/**
+ * Validate API configuration
+ */
+export function validateAPIConfig() {
+  const warnings: string[] = [];
+
+  if (!API_CONFIG.newsAPI.key) {
+    warnings.push('NewsAPI key not configured');
+  }
+
+  if (!API_CONFIG.alphaVantage.key) {
+    warnings.push('Alpha Vantage API key not configured');
+  }
+
+  if (!API_CONFIG.crypto.key) {
+    warnings.push('Crypto API key not configured');
+  }
+
+  if (!API_CONFIG.websocket.url) {
+    warnings.push('WebSocket URL not configured');
+  }
+
+  if (warnings.length > 0 && API_CONFIG.app.environment === 'production') {
+    console.error('Missing required API configuration:', warnings);
+  } else if (warnings.length > 0) {
+    console.warn('API configuration warnings:', warnings);
+  }
+
+  return warnings;
+}
+
+export default API_CONFIG;

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Services Index
+ * Central export point for all API clients and services
+ */
+
+export { newsAPI, default as NewsAPIClient } from './newsAPI';
+export { alphaVantage, default as AlphaVantageClient } from './alphaVantage';
+export { API_CONFIG, validateAPIConfig } from './config';
+
+// Initialize API validation on import
+if (import.meta.env.DEV) {
+  validateAPIConfig();
+}

--- a/src/services/newsAPI.ts
+++ b/src/services/newsAPI.ts
@@ -1,0 +1,110 @@
+import type { NewsResponse, NewsItem } from '../types/api';
+
+class NewsAPIClient {
+  private apiKey: string;
+  private baseUrl = 'https://newsapi.org/v2';
+
+  constructor(apiKey?: string) {
+    this.apiKey = apiKey || import.meta.env.VITE_NEWS_API_KEY || '';
+    
+    if (!this.apiKey) {
+      console.warn('NewsAPI key not configured');
+    }
+  }
+
+  /**
+   * Get top headlines from NewsAPI
+   */
+  async getTopHeadlines(params: {
+    country?: string;
+    category?: string;
+    q?: string;
+    pageSize?: number;
+    page?: number;
+  } = {}): Promise<NewsItem[]> {
+    const queryParams = new URLSearchParams({
+      apiKey: this.apiKey,
+      ...Object.fromEntries(
+        Object.entries(params).map(([k, v]) => [k, String(v)])
+      ),
+    });
+
+    try {
+      const response = await fetch(`${this.baseUrl}/top-headlines?${queryParams}`);
+      
+      if (!response.ok) {
+        throw new Error(`NewsAPI error: ${response.status} ${response.statusText}`);
+      }
+
+      const data: NewsResponse = await response.json();
+      return this.normalizeArticles(data.articles);
+    } catch (error) {
+      console.error('Failed to fetch top headlines:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Search for news articles
+   */
+  async searchNews(params: {
+    q: string;
+    searchIn?: string;
+    sources?: string;
+    domains?: string;
+    from?: string;
+    to?: string;
+    language?: string;
+    sortBy?: 'relevancy' | 'popularity' | 'publishedAt';
+    pageSize?: number;
+    page?: number;
+  }): Promise<NewsItem[]> {
+    const queryParams = new URLSearchParams({
+      apiKey: this.apiKey,
+      ...Object.fromEntries(
+        Object.entries(params).map(([k, v]) => [k, String(v)])
+      ),
+    });
+
+    try {
+      const response = await fetch(`${this.baseUrl}/everything?${queryParams}`);
+      
+      if (!response.ok) {
+        throw new Error(`NewsAPI error: ${response.status} ${response.statusText}`);
+      }
+
+      const data: NewsResponse = await response.json();
+      return this.normalizeArticles(data.articles);
+    } catch (error) {
+      console.error('Failed to search news:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * Normalize NewsAPI articles to internal format
+   */
+  private normalizeArticles(articles: NewsResponse['articles']): NewsItem[] {
+    return articles.map((article) => ({
+      id: `${article.source.name}-${article.publishedAt}-${article.title.substring(0, 20)}`,
+      source: article.source.name,
+      title: article.title,
+      description: article.description || '',
+      url: article.url,
+      imageUrl: article.urlToImage,
+      publishedAt: new Date(article.publishedAt),
+      content: article.content,
+    }));
+  }
+
+  /**
+   * Check if API key is configured
+   */
+  isConfigured(): boolean {
+    return !!this.apiKey;
+  }
+}
+
+// Export singleton instance
+export const newsAPI = new NewsAPIClient();
+export default newsAPI;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,78 @@
+// NewsAPI Types
+export interface NewsArticle {
+  source: {
+    id: string | null;
+    name: string;
+  };
+  author: string | null;
+  title: string;
+  description: string | null;
+  url: string;
+  urlToImage: string | null;
+  publishedAt: string;
+  content: string | null;
+}
+
+export interface NewsResponse {
+  status: string;
+  totalResults: number;
+  articles: NewsArticle[];
+}
+
+// Alpha Vantage Types
+export interface AlphaVantageQuote {
+  '01. symbol': string;
+  '02. open': string;
+  '03. high': string;
+  '04. low': string;
+  '05. price': string;
+  '06. volume': string;
+  '07. latest trading day': string;
+  '08. previous close': string;
+  '09. change': string;
+  '10. change percent': string;
+}
+
+export interface AlphaVantageTimeSeriesDaily {
+  'Meta Data': {
+    '1. Information': string;
+    '2. Symbol': string;
+    '3. Last Refreshed': string;
+    '4. Output Size': string;
+    '5. Time Zone': string;
+  };
+  'Time Series (Daily)': {
+    [date: string]: {
+      '1. open': string;
+      '2. high': string;
+      '3. low': string;
+      '4. close': string;
+      '5. volume': string;
+    };
+  };
+}
+
+export interface AlphaVantageGlobalQuote {
+  'Global Quote': AlphaVantageQuote;
+}
+
+// Normalized market data types for internal use
+export interface MarketQuote {
+  symbol: string;
+  price: number;
+  change: number;
+  changePercent: number;
+  volume: number;
+  timestamp: string;
+}
+
+export interface NewsItem {
+  id: string;
+  source: string;
+  title: string;
+  description: string;
+  url: string;
+  imageUrl: string | null;
+  publishedAt: Date;
+  content: string | null;
+}


### PR DESCRIPTION
## Summary
This PR implements the API client configuration for NewsAPI and Alpha Vantage as outlined in ZT-13.

## Changes
- Created type definitions for NewsAPI and Alpha Vantage responses
- Implemented NewsAPI client with:
  - Top headlines fetching
  - News search functionality
  - Article normalization to internal format
- Implemented Alpha Vantage client with:
  - Real-time quote fetching
  - Daily time series data
  - Intraday time series data
  - Symbol search
- Added central API configuration with environment variable management
- Included configuration validation
- Added comprehensive documentation

## Testing
All clients include:
- Error handling and logging
- Configuration validation
- Type safety
- Helper methods to check if API keys are configured

## Environment Variables
Requires the following in `.env`:
- `VITE_NEWS_API_KEY` - NewsAPI.org key
- `VITE_MARKET_DATA_API_KEY` - Alpha Vantage key

## Next Steps
- Test clients with real API keys
- Implement caching layer to respect rate limits
- Add WebSocket connections for real-time data

Closes ZT-13